### PR TITLE
Fix: change vec2 type to template type in visibility_polygon

### DIFF
--- a/visibility/visibility.hpp
+++ b/visibility/visibility.hpp
@@ -234,7 +234,7 @@ namespace geometry
             {
                 // Nearest line segment has changed
                 // Compute the intersection point with this segment
-                vec2 intersection;
+                Vector intersection;
                 ray<Vector> ray{ point, event.point() - point };
                 auto nearest_segment = *state.begin();
                 auto intersects = ray.intersects(nearest_segment, intersection);


### PR DESCRIPTION
There will be compile error if call `visibility_polygon(Vector point,  InputIterator begin, InputIterator end)`, where `point` is not of type `vec2`, for example, `std::vector<double>`